### PR TITLE
Add LoadCSS Function

### DIFF
--- a/language/en-GB.mod_sp_tweet.ini
+++ b/language/en-GB.mod_sp_tweet.ini
@@ -54,6 +54,8 @@ DURATION="Duration"
 DURATION_DESC="Morph Animation Duration"
 INTERVAL="Interval"
 INTERVAL_DESC="Periodical Animation Time"
+LOADCSS="Load SP Tweet CSS"
+LOADCSS_DESC="You can disable the SP Tweet CSS from loading, make sure you add the CSS in your own file."
 ##Frontend
 JUST_NOW="Just Now"
 ABOUT="About"


### PR DESCRIPTION
This function makes it possible to disable the CSS loading from the module.
This is needed for website optimalisation, by disabling the CSS load and adding the CSS to the template.css you have one HTTP request less.

By default it gets loaded so no B/C break.